### PR TITLE
Improve Linux hardware metrics collection

### DIFF
--- a/metrics/disk_metrics_common.go
+++ b/metrics/disk_metrics_common.go
@@ -8,7 +8,7 @@ var (
 			Name: "disk_usage_bytes",
 			Help: "Disk usage on system",
 		},
-		[]string{"disk", "model", "type"},
+		[]string{"disk", "model", "serial", "type"},
 	)
 
 	DiskUsagePercent = prometheus.NewGaugeVec(
@@ -16,7 +16,7 @@ var (
 			Name: "disk_usage_percent",
 			Help: "Disk usage on system",
 		},
-		[]string{"disk", "model"},
+		[]string{"disk", "model", "serial"},
 	)
 
 	DiskReadBytes = prometheus.NewGaugeVec(
@@ -24,7 +24,7 @@ var (
 			Name: "disk_read_bytes_per_second",
 			Help: "Disk read bytes per second",
 		},
-		[]string{"disk", "model"},
+		[]string{"disk", "model", "serial"},
 	)
 
 	DiskWriteBytes = prometheus.NewGaugeVec(
@@ -32,7 +32,7 @@ var (
 			Name: "disk_write_bytes_per_second",
 			Help: "Disk write bytes per second",
 		},
-		[]string{"disk", "model"},
+		[]string{"disk", "model", "serial"},
 	)
 
 	DiskHealthStatus = prometheus.NewGaugeVec(
@@ -40,6 +40,6 @@ var (
 			Name: "disk_health_status",
 			Help: "Health status of disk",
 		},
-		[]string{"disk", "type", "status", "size"},
+		[]string{"disk", "serial", "type", "status", "size"},
 	)
 )

--- a/metrics/disk_metrics_windows.go
+++ b/metrics/disk_metrics_windows.go
@@ -162,6 +162,7 @@ func RecordDiskUsage() {
 			}
 			DiskHealthStatus.With(prometheus.Labels{
 				"disk":   drive.FriendlyName,
+				"serial": drive.SerialNumber,
 				"type":   mediaTypeStr,
 				"status": healthStatusStr,
 				"size":   fmt.Sprintf("%d", drive.Size),
@@ -182,27 +183,31 @@ func RecordDiskUsage() {
 
 				// Записываем метрики использования диска
 				DiskUsage.With(prometheus.Labels{
-					"disk":  part.DeviceID,
-					"model": model,
-					"type":  "total",
+					"disk":   part.DeviceID,
+					"model":  model,
+					"serial": "unknown",
+					"type":   "total",
 				}).Set(float64(part.Size))
 
 				DiskUsage.With(prometheus.Labels{
-					"disk":  part.DeviceID,
-					"model": model,
-					"type":  "free",
+					"disk":   part.DeviceID,
+					"model":  model,
+					"serial": "unknown",
+					"type":   "free",
 				}).Set(float64(part.FreeSpace))
 
 				DiskUsage.With(prometheus.Labels{
-					"disk":  part.DeviceID,
-					"model": model,
-					"type":  "used",
+					"disk":   part.DeviceID,
+					"model":  model,
+					"serial": "unknown",
+					"type":   "used",
 				}).Set(float64(part.Size - part.FreeSpace))
 
 				usedPercent := (float64(part.Size-part.FreeSpace) / float64(part.Size)) * 100
 				DiskUsagePercent.With(prometheus.Labels{
-					"disk":  part.DeviceID,
-					"model": model,
+					"disk":   part.DeviceID,
+					"model":  model,
+					"serial": "unknown",
 				}).Set(usedPercent)
 
 				// Получаем и записываем метрики IO
@@ -218,13 +223,15 @@ func RecordDiskUsage() {
 					writeSpeed := float64(current.WriteBytes-prev.WriteBytes) / duration
 
 					DiskReadBytes.With(prometheus.Labels{
-						"disk":  part.DeviceID,
-						"model": model,
+						"disk":   part.DeviceID,
+						"model":  model,
+						"serial": "unknown",
 					}).Set(readSpeed)
 
 					DiskWriteBytes.With(prometheus.Labels{
-						"disk":  part.DeviceID,
-						"model": model,
+						"disk":   part.DeviceID,
+						"model":  model,
+						"serial": "unknown",
 					}).Set(writeSpeed)
 				}
 				prevIO[part.DeviceID] = current

--- a/metrics/memory_metrics_linux.go
+++ b/metrics/memory_metrics_linux.go
@@ -3,6 +3,7 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os/exec"
@@ -81,6 +82,33 @@ func RecordMemoryUsage() {
 }
 
 func parseMemoryModules() ([]memoryModule, error) {
+	var modules []memoryModule
+	var errs []error
+
+	if dmidecode, err := parseMemoryModulesFromDmidecode(); err == nil && len(dmidecode) > 0 {
+		modules = dmidecode
+	} else {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(modules) == 0 {
+		if lshw, err := parseMemoryModulesFromLshw(); err == nil && len(lshw) > 0 {
+			modules = lshw
+		} else if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(modules) == 0 && len(errs) > 0 {
+		return modules, errors.Join(errs...)
+	}
+
+	return modules, nil
+}
+
+func parseMemoryModulesFromDmidecode() ([]memoryModule, error) {
 	cmd := exec.Command("dmidecode", "--type", "memory")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -153,9 +181,6 @@ func parseMemoryModules() ([]memoryModule, error) {
 			continue
 		}
 
-		module.Manufacturer = sanitizeMemoryField(module.Manufacturer)
-		module.PartNumber = sanitizeMemoryField(module.PartNumber)
-		module.SerialNumber = sanitizeMemoryField(module.SerialNumber)
 		if module.Speed == "" {
 			module.Speed = "unknown"
 		}
@@ -164,6 +189,103 @@ func parseMemoryModules() ([]memoryModule, error) {
 	}
 
 	return modules, nil
+}
+
+func parseMemoryModulesFromLshw() ([]memoryModule, error) {
+	cmd := exec.Command("lshw", "-class", "memory")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	var modules []memoryModule
+	lines := strings.Split(string(output), "\n")
+	module := memoryModule{}
+	inBank := false
+
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if strings.HasPrefix(line, "*-bank") || strings.HasPrefix(line, "bank:") {
+			if module.SizeBytes > 0 {
+				if module.Speed == "" {
+					module.Speed = "unknown"
+				}
+				modules = append(modules, module)
+			}
+			module = memoryModule{}
+			inBank = true
+			continue
+		}
+
+		if !inBank {
+			continue
+		}
+
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		switch strings.ToLower(key) {
+		case "size":
+			size, ok := parseMemoryCapacity(value)
+			if ok {
+				module.SizeBytes = size
+			}
+		case "vendor":
+			module.Manufacturer = sanitizeMemoryField(value)
+		case "product":
+			module.PartNumber = sanitizeMemoryField(value)
+		case "serial":
+			module.SerialNumber = sanitizeMemoryField(value)
+		case "clock":
+			module.Speed = normalizeMemorySpeed(value)
+		}
+	}
+
+	if module.SizeBytes > 0 {
+		if module.Speed == "" {
+			module.Speed = "unknown"
+		}
+		modules = append(modules, module)
+	}
+
+	return modules, nil
+}
+
+func parseMemoryCapacity(value string) (uint64, bool) {
+	fields := strings.Fields(value)
+	if len(fields) == 0 {
+		return 0, false
+	}
+
+	number, err := strconv.ParseFloat(strings.TrimSuffix(fields[0], "GiB"), 64)
+	if err == nil && strings.Contains(strings.ToLower(value), "gib") {
+		return uint64(number * 1024 * 1024 * 1024), true
+	}
+
+	number, err = strconv.ParseFloat(strings.TrimSuffix(fields[0], "MiB"), 64)
+	if err == nil && strings.Contains(strings.ToLower(value), "mib") {
+		return uint64(number * 1024 * 1024), true
+	}
+
+	rawNumber, err := strconv.ParseUint(fields[0], 10, 64)
+	if err != nil || len(fields) < 2 {
+		return 0, false
+	}
+
+	unit := strings.ToUpper(fields[1])
+	switch {
+	case strings.HasPrefix(unit, "MB"):
+		return rawNumber * 1024 * 1024, true
+	case strings.HasPrefix(unit, "GB"):
+		return rawNumber * 1024 * 1024 * 1024, true
+	}
+
+	return 0, false
 }
 
 func normalizeMemorySpeed(value string) string {
@@ -186,18 +308,19 @@ func normalizeMemorySpeed(value string) string {
 }
 
 func sanitizeMemoryField(value string) string {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
+	cleaned := strings.Trim(value, "\r\n\t")
+	if cleaned == "" {
 		return "unknown"
+	}
+
+	trimmed := strings.TrimSpace(cleaned)
+	if trimmed == "" {
+		return cleaned
 	}
 
 	lower := strings.ToLower(trimmed)
 	switch lower {
 	case "unknown", "none", "n/a", "not specified", "no module installed":
-		return "unknown"
-	}
-
-	if trimmed == "0000" {
 		return "unknown"
 	}
 

--- a/metrics/network_metrics_linux.go
+++ b/metrics/network_metrics_linux.go
@@ -39,6 +39,10 @@ func RecordNetworkMetrics() {
 
 			displayNames := make(map[string]string, len(interfaces))
 			for _, iface := range interfaces {
+				if iface.Name == "lo" {
+					continue
+				}
+
 				if iface.Name == "" {
 					continue
 				}
@@ -65,6 +69,10 @@ func RecordNetworkMetrics() {
 			}
 
 			for _, stat := range stats {
+				if stat.Name == "lo" {
+					continue
+				}
+
 				display := displayNames[stat.Name]
 				if display == "" {
 					display = friendlyInterfaceName(stat.Name)

--- a/metrics/uuid_metrics_linux.go
+++ b/metrics/uuid_metrics_linux.go
@@ -110,9 +110,9 @@ func GenerateHardwareUUID() (string, error) {
 		sb.WriteString(memorySummary)
 	}
 
-	for _, gpu := range discoverGPUNames() {
+	for _, gpu := range discoverGPUDevices() {
 		sb.WriteString("|")
-		sb.WriteString(gpu)
+		sb.WriteString(gpu.Name)
 	}
 
 	hash := sha256.Sum256([]byte(sb.String()))


### PR DESCRIPTION
## Summary
- adjust Linux memory module parsing to report manufacturer data and declared capacities using dmidecode with an lshw fallback
- report only physical Linux disks with model and serial labels and align disk health status with the new labels
- hide loopback interfaces from network metrics and expose real GPU memory values via sysfs, lspci, or nvidia-smi

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e8d7c4f0888333a295061b0ef5b9f7