### PR TITLE
Fix Inno Setup script terminator for release build

### DIFF
--- a/simple_install.iss
+++ b/simple_install.iss
@@ -131,4 +131,4 @@ begin
     if ApiPassword <> '' then
       SaveStringToFile(PasswordPath, ApiPassword, False);
   end;
-end
+end;


### PR DESCRIPTION
## Summary
- add the missing semicolon to the installer script to restore successful Inno Setup compilation when passing version parameters from tags

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920233e4ad08333910ff9e24a4f4b98)