### PR TITLE
Normalize Inno Setup script line endings

### DIFF
--- a/simple_install.iss
+++ b/simple_install.iss
@@ -1,4 +1,5 @@
 ; Install script for NITRINOnet Control Manager (Шаг 1: Простой установщик файлов)
+; Stored with Windows (CRLF) line endings for Inno Setup compatibility.
 
 ; Параметризуем версию установщика через препроцессор
 #ifndef MyAppVersion
@@ -131,4 +132,4 @@ begin
     if ApiPassword <> '' then
       SaveStringToFile(PasswordPath, ApiPassword, False);
   end;
-end
+end;


### PR DESCRIPTION
## Summary
- document and normalize Windows CRLF line endings in the installer script to keep Inno Setup builds working when consuming tag-based versions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920233e4ad08333910ff9e24a4f4b98)